### PR TITLE
name default policies uniquely (include table name)

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -47,7 +47,7 @@ node['iptables-ng']['rules'].each do |table, chains|
 
   # Create default policies unless they exist
   chains.each do |chain, p|
-    iptables_ng_policy "default-policy-#{chain}" do
+    iptables_ng_policy "default-policy-#{table}-#{chain}" do
       chain  chain
       table  table
       policy policy['default']


### PR DESCRIPTION
Because the default policies loop over both tables and chains but the default policy only interpolates the chain name, iptables-ng::install ends up redefining resources over and over.

``` bash
W, [2013-10-16T12:55:02.466085 #30038]  WARN -- : Cloning resource attributes for iptables-ng_policy[default-policy-OUTPUT] from prior resource (CHEF-3694)
W, [2013-10-16T12:55:02.472805 #30038]  WARN -- : Previous iptables-ng_policy[default-policy-OUTPUT]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.473262 #30038]  WARN -- : Current  iptables-ng_policy[default-policy-OUTPUT]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.495833 #30038]  WARN -- : Cloning resource attributes for iptables-ng_policy[default-policy-INPUT] from prior resource (CHEF-3694)
W, [2013-10-16T12:55:02.496136 #30038]  WARN -- : Previous iptables-ng_policy[default-policy-INPUT]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.497080 #30038]  WARN -- : Current  iptables-ng_policy[default-policy-INPUT]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.503949 #30038]  WARN -- : Cloning resource attributes for iptables-ng_policy[default-policy-OUTPUT] from prior resource (CHEF-3694)
W, [2013-10-16T12:55:02.504200 #30038]  WARN -- : Previous iptables-ng_policy[default-policy-OUTPUT]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.504533 #30038]  WARN -- : Current  iptables-ng_policy[default-policy-OUTPUT]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.509342 #30038]  WARN -- : Cloning resource attributes for iptables-ng_policy[default-policy-FORWARD] from prior resource (CHEF-3694)
W, [2013-10-16T12:55:02.509660 #30038]  WARN -- : Previous iptables-ng_policy[default-policy-FORWARD]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.510257 #30038]  WARN -- : Current  iptables-ng_policy[default-policy-FORWARD]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.513741 #30038]  WARN -- : Cloning resource attributes for iptables-ng_policy[default-policy-PREROUTING] from prior resource (CHEF-3694)
W, [2013-10-16T12:55:02.514436 #30038]  WARN -- : Previous iptables-ng_policy[default-policy-PREROUTING]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.515117 #30038]  WARN -- : Current  iptables-ng_policy[default-policy-PREROUTING]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.518671 #30038]  WARN -- : Cloning resource attributes for iptables-ng_policy[default-policy-POSTROUTING] from prior resource (CHEF-3694)
W, [2013-10-16T12:55:02.522228 #30038]  WARN -- : Previous iptables-ng_policy[default-policy-POSTROUTING]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.522714 #30038]  WARN -- : Current  iptables-ng_policy[default-policy-POSTROUTING]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.533370 #30038]  WARN -- : Cloning resource attributes for iptables-ng_policy[default-policy-OUTPUT] from prior resource (CHEF-3694)
W, [2013-10-16T12:55:02.533675 #30038]  WARN -- : Previous iptables-ng_policy[default-policy-OUTPUT]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.534306 #30038]  WARN -- : Current  iptables-ng_policy[default-policy-OUTPUT]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.541623 #30038]  WARN -- : Cloning resource attributes for iptables-ng_policy[default-policy-PREROUTING] from prior resource (CHEF-3694)
W, [2013-10-16T12:55:02.542114 #30038]  WARN -- : Previous iptables-ng_policy[default-policy-PREROUTING]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
W, [2013-10-16T12:55:02.542376 #30038]  WARN -- : Current  iptables-ng_policy[default-policy-PREROUTING]: /opt/rtpg/share/chef/cookbooks/iptables-ng/recipes/install.rb:51:in `block (2 levels) in from_file'
```

The warning is detailed in [CHEF-3694](https://tickets.opscode.com/browse/CHEF-3694).  Essentially, redefining a resource is easy to do by accident and Opscode wants to discourage the practice of doing so on purpose.  Chef 10.18.0 and 11.0.0 and higher emit a warning (which is in this case spurious).

This patch names the default policies using both table and chain name, which means that you don't get two resources with the same name.

I'm not sure how to fit this into a test suite, because the actual iptables output was fine - Chef was just moaning about the redefinition, which only shows up in the Chef log.
