### PR TITLE
Fixes hash definitions for Ruby 1.8

### DIFF
--- a/libraries/restart_service.rb
+++ b/libraries/restart_service.rb
@@ -32,7 +32,7 @@ module Iptables
         return if node['iptables-ng']['service_ipv4'] == node['iptables-ng']['service_ipv6'] and ip_version == 6
 
         Chef::Resource::Service.new(node['iptables-ng']["service_ipv#{ip_version}"], run_context).tap do |service|
-          service.supports(status: true, restart: true)
+          service.supports(:status => true, :restart => true)
           service.run_action(:enable)
           service.run_action(:restart)
         end

--- a/resources/policy.rb
+++ b/resources/policy.rb
@@ -21,9 +21,9 @@
 actions        :create, :create_if_missing, :delete
 default_action :create
 
-attribute :chain,  kind_of: String, name_attribute: true, equal_to: %w{INPUT OUTPUT FORWARD PREROUTING POSTROUTING}
-attribute :table,  kind_of: String, default: 'filter',    equal_to: %w{filter nat mangle raw}
-attribute :policy, kind_of: String, default: 'ACCEPT [0:0]'
+attribute :chain,  :kind_of => String, :name_attribute => true, :equal_to => %w{INPUT OUTPUT FORWARD PREROUTING POSTROUTING}
+attribute :table,  :kind_of => String, :default => 'filter',    :equal_to => %w{filter nat mangle raw}
+attribute :policy, :kind_of => String, :default => 'ACCEPT [0:0]'
 
 
 def initialize(*args)

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -21,11 +21,11 @@
 actions        :create, :create_if_missing, :delete
 default_action :create
 
-attribute :name,       kind_of: String, name_attribute: true
-attribute :chain,      kind_of: String, default: 'INPUT',  equal_to: %w{INPUT OUTPUT FORWARD PREROUTING POSTROUTING}
-attribute :table,      kind_of: String, default: 'filter', equal_to: %w{filter nat mangle raw}
-attribute :rule,       kind_of: [ Array, String ],  default: []
-attribute :ip_version, kind_of: [ Array, Integer ], default: [4, 6], equal_to: [ [4, 6], 4, 6 ]
+attribute :name,       :kind_of => String, :name_attribute => true
+attribute :chain,      :kind_of => String, :default => 'INPUT',  :equal_to => %w{INPUT OUTPUT FORWARD PREROUTING POSTROUTING}
+attribute :table,      :kind_of => String, :default => 'filter', :equal_to => %w{filter nat mangle raw}
+attribute :rule,       :kind_of => [ Array, String ],  :default => []
+attribute :ip_version, :kind_of => [ Array, Integer ], :default => [4, 6], :equal_to => [ [4, 6], 4, 6 ]
 
 
 def initialize(*args)


### PR DESCRIPTION
Several of our old systems still use Ruby 1.8. This patch makes the cookbook run for me.
