### PR TITLE
Adds settings for Debian Wheezy

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,9 +34,16 @@ when 'debian'
   # Debian squeeze (and before) only support an outdated version
   # of iptables-persistent, which is not capable of ipv6.
   # Furthermore, restarting the service doesn't properly reload the rules
-  # default['iptables-ng']['service_ipv4'] = 'iptables-persistent'
-  default['iptables-ng']['script_ipv4'] = '/etc/iptables/rules'
-  default['iptables-ng']['script_ipv6'] = '/etc/iptables/rules.v6'
+  if node['platform_version'].to_f < 7.0
+    # default['iptables-ng']['service_ipv4'] = 'iptables-persistent'
+    default['iptables-ng']['script_ipv4'] = '/etc/iptables/rules'
+    default['iptables-ng']['script_ipv6'] = '/etc/iptables/rules.v6'
+  else
+    default['iptables-ng']['service_ipv4'] = 'iptables-persistent'
+    default['iptables-ng']['service_ipv6'] = 'iptables-persistent'
+    default['iptables-ng']['script_ipv4'] = '/etc/iptables/rules.v4'
+    default['iptables-ng']['script_ipv6'] = '/etc/iptables/rules.v6'
+  end
 
 when 'ubuntu'
   default['iptables-ng']['service_ipv4'] = 'iptables-persistent'


### PR DESCRIPTION
Wheezy has a newer iptables-persistent command that supports ipv6.
