### PR TITLE
Adjust hash syntax for ruby 1.8.7 compatibility

### DIFF
--- a/libraries/restart_service.rb
+++ b/libraries/restart_service.rb
@@ -32,7 +32,7 @@ module Iptables
         return if node['iptables-ng']['service_ipv4'] == node['iptables-ng']['service_ipv6'] and ip_version == 6
 
         Chef::Resource::Service.new(node['iptables-ng']["service_ipv#{ip_version}"], run_context).tap do |service|
-          service.supports(status: true, restart: true)
+          service.supports(:status => true, :restart => true)
           service.run_action(:enable)
           service.run_action(:restart)
         end

--- a/resources/chain.rb
+++ b/resources/chain.rb
@@ -23,9 +23,9 @@ default_action :create
 
 # linux/netfilter/x_tables.h doesn't restrict chains very tightly.  Just a string token
 # with a max length of XT_EXTENSION_MAXLEN (29 in all 3.x headers I could find)
-attribute :chain,  kind_of: String, name_attribute: true,  regex: /^\w{1,29}$/
-attribute :table,  kind_of: String, default: 'filter', equal_to: %w{filter nat mangle raw}
-attribute :policy, kind_of: String, default: 'ACCEPT [0:0]'
+attribute :chain,  :kind_of => String, :name_attribute => true,  :regex => /^\w{1,29}$/
+attribute :table,  :kind_of => String, :default => 'filter', :equal_to => %w{filter nat mangle raw}
+attribute :policy, :kind_of => String, :default => 'ACCEPT [0:0]'
 
 
 def initialize(*args)

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -21,13 +21,13 @@
 actions        :create, :create_if_missing, :delete
 default_action :create
 
-attribute :name,       kind_of: String, name_attribute: true
+attribute :name,       :kind_of => String, :name_attribute => true
 # linux/netfilter/x_tables.h doesn't restrict chains very tightly.  Just a string token
 # with a max length of XT_EXTENSION_MAXLEN (29 in all 3.x headers I could find)
-attribute :chain,      kind_of: String, default: 'INPUT',  regex: /^\w{1,29}$/
-attribute :table,      kind_of: String, default: 'filter', equal_to: %w{filter nat mangle raw}
-attribute :rule,       kind_of: [ Array, String ],  default: []
-attribute :ip_version, kind_of: [ Array, Integer ], default: [4, 6], equal_to: [ [4, 6], 4, 6 ]
+attribute :chain,      :kind_of => String, :default => 'INPUT',  :regex => /^\w{1,29}$/
+attribute :table,      :kind_of => String, :default => 'filter', :equal_to => %w{filter nat mangle raw}
+attribute :rule,       :kind_of => [ Array, String ],  :default => []
+attribute :ip_version, :kind_of => [ Array, Integer ], :default => [4, 6], :equal_to => [ [4, 6], 4, 6 ]
 
 def initialize(*args)
   super


### PR DESCRIPTION
The newer hash syntax (key: value vs. :key => value) is incompatible
with ruby 1.8.7 and thus with anything deployed on Amazon Web Services.
Since the only way of configuring instances with AWS is by using Chef I
would strongly suggest to retain 1.8.7 compatibility, at least until
Amazon moves to using 1.9.x within its Chef environment.

There are no downsides to using the old syntax. It still works with ruby
2.x and 1.9.x.

Reference: https://forums.aws.amazon.com/thread.jspa?threadID=140115
