### PR TITLE
Add support for custom IP versions from the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ depends 'iptables-ng'
 While iptables-ng tries to automatically determine the correct settings and defaults for your distribution, it might be necessary to adapt them in certian cases. You can configure the behaviour of iptables-ng using the following attributes:
 
 ```ruby
+# The ip versions to manage iptables for
+node['iptables-ng']['enabled_ip_versions'] = [4, 6]
+
 # An array of packages to install.
 # This should install iptables and ip6tables,
 # as well as a system service that takes care of reloading the rules
@@ -186,7 +189,7 @@ iptables_ng_rule 'custom' do
   chain      'INPUT'      # Chain to use. Defaults to 'INPUT'
   table      'filter'     # Table to use. Defaults to 'filter'
   ip_version 4            # Integer or Array of IP versions to create the rules for.
-                          # Defaults to [4, 6]
+                          # Defaults to node['iptables-ng']['enabled_ip_versions']
   rule       '-j ACCEPT'  # String or Array containing the rule(s). (Required)
 
   action :create          # Supported actions: :create, :create_if_missing, :delete

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# Which IP versions to manage rules for
+default['iptables-ng']['enabled_ip_versions'] = [4, 6]
+
 # Packages to install
 default['iptables-ng']['packages'] = case node['platform_family']
 when 'debian'

--- a/recipes/manage.rb
+++ b/recipes/manage.rb
@@ -27,7 +27,7 @@ ruby_block 'create_rules' do
       include Iptables::Manage
     end
 
-    [4, 6].each do |ip_version|
+    node['iptables-ng']['enabled_ip_versions'].each do |ip_version|
       create_iptables_rules(ip_version)
     end
   end
@@ -41,7 +41,7 @@ ruby_block 'restart_iptables' do
       include Iptables::Manage
     end
 
-    [4, 6].each do |ip_version|
+    node['iptables-ng']['enabled_ip_versions'].each do |ip_version|
       restart_service(ip_version)
     end
   end

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -27,7 +27,7 @@ attribute :name,       kind_of: String, name_attribute: true
 attribute :chain,      kind_of: String, default: 'INPUT',  regex: /^\w{1,29}$/
 attribute :table,      kind_of: String, default: 'filter', equal_to: %w{filter nat mangle raw}
 attribute :rule,       kind_of: [ Array, String ],  default: []
-attribute :ip_version, kind_of: [ Array, Integer ], default: [4, 6], equal_to: [ [4, 6], 4, 6 ]
+attribute :ip_version, kind_of: [ Array, Integer ], default: node['iptables-ng']['enabled_ip_versions'], equal_to: [ [4, 6], 4, 6 ]
 
 def initialize(*args)
   super


### PR DESCRIPTION
Let the user whether to create rules for IPV4, IPV6, or both.

Default to both.
