### PR TITLE
Update default rule processing for ruby 1.8

### DIFF
--- a/libraries/create_iptables_rules.rb
+++ b/libraries/create_iptables_rules.rb
@@ -50,7 +50,11 @@ module Iptables
         iptables_restore << "*#{table}\n"
 
         # Get default policies and rules for this chain
-        default_policies = chains.inject({}) {|new_chain, rule| new_chain[rule[0]] = rule[1].select{|k, v| k == 'default'}; new_chain }
+        # 
+        # ruby 1.8: Hash#select returns an array of key value pairs, not a Hash
+        default_policies = chains.inject({}) {|new_chain, rule| new_chain[rule[0]] = Hash[rule[1].select{|k, v| k == 'default'}]; new_chain }
+
+        # ruby 1.8: Hash#reject, on the other hand, returns a hash
         all_chain_rules  = chains.inject({}) {|new_chain, rule| new_chain[rule[0]] = rule[1].reject{|k, v| k == 'default'}; new_chain }
 
         # Apply default policies first


### PR DESCRIPTION
In Ruby 1.8, Hash#select returns an array of [key, value] pairs, in Ruby
1.9+ it returns a Hash.

Rework of #15 on top of ruby-1.8-compat, again specifically to support AWS OpsWorks (re: #9)
