### PR TITLE
Data bag support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,3 +76,4 @@ else
 end
 
 default['iptables-ng']['data_bag'] = "iptables-ng"
+default["iptables-ng"]["secret"] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -74,3 +74,5 @@ else
   default['iptables-ng']['script_ipv4'] = '/etc/iptables-rules.ipt'
   default['iptables-ng']['script_ipv6'] = '/etc/ip6tables-rules.ipt'
 end
+
+default['iptables-ng']['data_bag'] = "iptables-ng"

--- a/recipes/data_bag.rb
+++ b/recipes/data_bag.rb
@@ -1,10 +1,10 @@
 rules = Mash.new
 bag = node['iptables-ng']['data_bag']
 
-node["iptables-ng"]["data_bags"].each do |item|
+Array(node['iptables-ng']['data_bags']).each do |item|
   bag_item  = begin
-    if node["iptables-ng"]["secret"]
-      secret = Chef::EncryptedDataBagItem.load_secret(node["iptables-ng"]["secret"])
+    if node['iptables-ng"]["secret']
+      secret = Chef::EncryptedDataBagItem.load_secret(node['iptables-ng']['secret'])
       Chef::EncryptedDataBagItem.load(bag, item, secret)
     else
       data_bag_item(bag, item)
@@ -14,8 +14,7 @@ node["iptables-ng"]["data_bags"].each do |item|
     Hash.new
   end
 
-  rules = Chef::Mixin::DeepMerge.merge(rules, bag_item["rules"])
-
+  rules = Chef::Mixin::DeepMerge.merge(rules, bag_item['rules'])
 end
 
 node.set['iptables-ng']['rules'] = rules

--- a/recipes/data_bag.rb
+++ b/recipes/data_bag.rb
@@ -3,7 +3,7 @@ bag = node['iptables-ng']['data_bag']
 
 Array(node['iptables-ng']['data_bags']).each do |item|
   bag_item  = begin
-    if node['iptables-ng"]["secret']
+    if node['iptables-ng']['secret']
       secret = Chef::EncryptedDataBagItem.load_secret(node['iptables-ng']['secret'])
       Chef::EncryptedDataBagItem.load(bag, item, secret)
     else

--- a/recipes/data_bag.rb
+++ b/recipes/data_bag.rb
@@ -1,0 +1,22 @@
+rules = Mash.new
+bag = node['iptables-ng']['data_bag']
+
+node["iptables-ng"]["data_bags"].each do |item|
+  bag_item  = begin
+    if node["iptables-ng"]["secret"]
+      secret = Chef::EncryptedDataBagItem.load_secret(node["iptables-ng"]["secret"])
+      Chef::EncryptedDataBagItem.load(bag, item, secret)
+    else
+      data_bag_item(bag, item)
+    end
+  rescue => ex
+    Chef::Log.info("Data bag #{bag} not found (#{ex}), so skipping")
+    Hash.new
+  end
+
+  rules = Chef::Mixin::DeepMerge.merge(rules, bag_item["rules"])
+
+end
+
+node.set['iptables-ng']['rules'] = rules
+include_recipe 'iptables-ng'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,17 +22,20 @@ include_recipe 'iptables-ng::install'
 
 # Apply rules from node attributes
 node['iptables-ng']['rules'].each do |table, chains|
+
+  next unless chains
+
   chains.each do |chain, p|
     # policy is read only, duplicate it
     policy = p.dup
-
+    
     # Apply chain policy
     iptables_ng_chain "attribute-policy-#{chain}" do
       chain  chain
       table  table
       policy policy.delete('default')
     end
-
+    
     # Apply rules
     policy.each do |name, r|
       iptables_ng_rule "#{name}-#{table}-#{chain}-attribute-rule" do
@@ -44,3 +47,4 @@ node['iptables-ng']['rules'].each do |table, chains|
     end
   end
 end
+

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -39,6 +39,8 @@ node['iptables-ng']['rules'].each do |table, chains|
     mode 00700
   end
 
+  next unless chains
+
   # Create default policies unless they exist
   chains.each do |chain, policy|
     iptables_ng_chain "default-policy-#{table}-#{chain}" do


### PR DESCRIPTION
Can you check my pull request? It adds data bag support to iptables-ng, in my case it very usefl. I'm add databags via node attributes like:
```
                    "iptables-ng" => {
                      "data_bag_name" => "firewall",
                      "data_bags" => [ "default", "relay_kh", "netflow_kh", "ospf", "vncproxy", "ssh", "vps_kh", "corosync" ]
                    },
```

And in each databag i have
```
{
    "id": "ospf",
    "rules": {
        "filter": {
            "INPUT": {
                "ospf": {
                    "rule": "-s 10.220.0.0/16 -d 224.0.0.5/30 -p 89 -j ACCEPT",
                    "ip_version": 4
                }
            }
        }
    }
}
```