### PR TITLE
Fix ip_version in rule resource

### DIFF
--- a/recipes/manage.rb
+++ b/recipes/manage.rb
@@ -27,7 +27,7 @@ ruby_block 'create_rules' do
       include Iptables::Manage
     end
 
-    node['iptables-ng']['enabled_ip_versions'].each do |ip_version|
+    Array(node['iptables-ng']['enabled_ip_versions']).each do |ip_version|
       create_iptables_rules(ip_version)
     end
   end
@@ -41,7 +41,7 @@ ruby_block 'restart_iptables' do
       include Iptables::Manage
     end
 
-    node['iptables-ng']['enabled_ip_versions'].each do |ip_version|
+    Array(node['iptables-ng']['enabled_ip_versions']).each do |ip_version|
       restart_service(ip_version)
     end
   end

--- a/resources/rule.rb
+++ b/resources/rule.rb
@@ -27,7 +27,7 @@ attribute :name,       kind_of: String, name_attribute: true
 attribute :chain,      kind_of: String, default: 'INPUT',  regex: /^[\w-]{1,29}$/
 attribute :table,      kind_of: String, default: 'filter', equal_to: %w(filter nat mangle raw)
 attribute :rule,       kind_of: [Array, String],  default: []
-attribute :ip_version, kind_of: [Array, Integer], default: node['iptables-ng']['enabled_ip_versions'], equal_to: [[4, 6], 4, 6]
+attribute :ip_version, kind_of: [Array, Integer], default: node['iptables-ng']['enabled_ip_versions'], equal_to: [[4, 6], [4], [6], 4, 6]
 
 def initialize(*args)
   super


### PR DESCRIPTION
This PR fixes problems we experienced while trying to set `node['iptables-ng']['enabled_ip_versions'] = 4`:
- The manager.rb change is needed in order to iterate over a single Integer value
- The rules.rb change adds consistency in handling the input as an array

P.S. Thanks for the very useful cookbook
