### PR TITLE
Use service 'netfilter-persistent' for ubuntu 14.10 or greater

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -58,8 +58,13 @@ when 'debian'
   end
 
 when 'ubuntu'
-  default['iptables-ng']['service_ipv4'] = 'iptables-persistent'
-  default['iptables-ng']['service_ipv6'] = 'iptables-persistent'
+  if node['platform_version'].to_f >= 14.10
+    default['iptables-ng']['service_ipv4'] = 'netfilter-persistent'
+    default['iptables-ng']['service_ipv6'] = 'netfilter-persistent'
+  else
+    default['iptables-ng']['service_ipv4'] = 'iptables-persistent'
+    default['iptables-ng']['service_ipv6'] = 'iptables-persistent'
+  end
   default['iptables-ng']['script_ipv4'] = '/etc/iptables/rules.v4'
   default['iptables-ng']['script_ipv6'] = '/etc/iptables/rules.v6'
 


### PR DESCRIPTION
It seems the service 'iptables-persistent' does not exist anymore on ubuntu 14.10 and has been renamed to 'netfilter-persistent'
