### PR TITLE
allow for different scratch dirs, instead of hardcoded to /etc/iptables....

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Contrary to other iptables cookbooks, this cookbook installs iptables and mainta
 
 It provides LWRPs as well as recipes which can handle iptables rules set in the nodes attributes.
 
-It uses the directory ```/etc/iptables.d``` to store and maintain its rules. I'm trying to be as compatible as much as possible to all distributions out there.
+It uses the directory ```#{node['iptables-ng']['scratch_dir']}``` (/etc/iptables.d by default) to store and maintain its rules. I'm trying to be as compatible as much as possible to all distributions out there.
 
 ## Requirements
 
@@ -145,7 +145,7 @@ You can also delete old rules by specifying a custom action.
 
 ## install
 
-The installs recipe installs iptables packages, makes sure that ```/etc/iptables.d``` is created and sets all default policies to "ACCEPT", unless they are already configured.
+The install recipe installs iptables packages, makes sure that ```#{node['iptables-ng']['scratch_dir']}``` (/etc/iptables.d by default) is created and sets all default policies to "ACCEPT", unless they are already configured.
 
 On Debian and Ubuntu systems, it also removes the "ufw" package, as it might interferre with this cookbook.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,6 +40,9 @@ else
   %w(iptables)
 end
 
+#Where to store rules as they are being built
+default['iptables-ng']['scratch_dir'] = '/etc/iptables.d'
+
 # Where the rules are stored and how they are executed
 case node['platform']
 when 'debian'

--- a/libraries/create_iptables_rules.rb
+++ b/libraries/create_iptables_rules.rb
@@ -29,10 +29,10 @@ module Iptables
 
       # Retrieve all iptables rules for this ip_version,
       # as well as default policies
-      Dir["/etc/iptables.d/*/*/*.rule_v#{ip_version}",
-          '/etc/iptables.d/*/*/default'].each do |path|
+      Dir["#{node['iptables-ng']['scratch_dir']}/*/*/*.rule_v#{ip_version}",
+          "#{node['iptables-ng']['scratch_dir']}/*/*/default"].each do |path|
 
-        # /etc/iptables.d/#{table}/#{chain}/#{rule}.rule_v#{ip_version}
+        # #{node['iptables-ng']['scratch_dir']}/#{table}/#{chain}/#{rule}.rule_v#{ip_version}
         table, chain, filename = path.split('/')[3..5]
         rule = ::File.basename(filename)
 

--- a/providers/chain.rb
+++ b/providers/chain.rb
@@ -38,14 +38,14 @@ def edit_chain(exec_action)
     policy = '- [0:0]'
   end
 
-  directory "/etc/iptables.d/#{new_resource.table}/#{new_resource.chain}" do
+  directory "#{node['iptables-ng']['scratch_dir']}/#{new_resource.table}/#{new_resource.chain}" do
     owner  'root'
     group  node['root_group']
     mode   00700
     not_if { exec_action == :delete }
   end
 
-  rule_path = "/etc/iptables.d/#{new_resource.table}/#{new_resource.chain}/default"
+  rule_path = "#{node['iptables-ng']['scratch_dir']}/#{new_resource.table}/#{new_resource.chain}/default"
 
   r = file rule_path do
     owner    'root'

--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -39,14 +39,14 @@ def edit_rule(exec_action)
     rule_file = ''
     Array(new_resource.rule).each { |r| rule_file << "--append #{new_resource.chain} #{r.chomp}\n" }
 
-    directory "/etc/iptables.d/#{new_resource.table}/#{new_resource.chain}" do
+    directory "#{node['iptables-ng']['scratch_dir']}/#{new_resource.table}/#{new_resource.chain}" do
       owner  'root'
       group  node['root_group']
       mode   00700
       not_if { exec_action == :delete }
     end
 
-    rule_path = "/etc/iptables.d/#{new_resource.table}/#{new_resource.chain}/#{new_resource.name}.rule_v#{ip_version}"
+    rule_path = "#{node['iptables-ng']['scratch_dir']}/#{new_resource.table}/#{new_resource.chain}/#{new_resource.name}.rule_v#{ip_version}"
 
     r = file rule_path do
       owner    'root'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -30,7 +30,7 @@ package 'ufw' do
 end
 
 # Create directories
-directory '/etc/iptables.d' do
+directory "#{node['iptables-ng']['scratch_dir']}" do
   mode   00700
 end
 
@@ -38,7 +38,7 @@ node['iptables-ng']['rules'].each do |table, chains|
   # Skip deactivated tables
   next unless node['iptables-ng']['enabled_tables'].include?(table)
 
-  directory "/etc/iptables.d/#{table}" do
+  directory "#{node['iptables-ng']['scratch_dir']}/#{table}" do
     mode 00700
   end
 

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -25,10 +25,10 @@ describe 'iptables-ng::install' do
   end
 
   it 'should create directory for chains' do
-    expect(chef_run).to create_directory('/etc/iptables.d/filter')
-    expect(chef_run).to create_directory('/etc/iptables.d/nat')
-    expect(chef_run).to create_directory('/etc/iptables.d/mangle')
-    expect(chef_run).to create_directory('/etc/iptables.d/raw')
+    expect(chef_run).to create_directory("#{node['iptables-ng']['scratch_dir']}/filter")
+    expect(chef_run).to create_directory("#{node['iptables-ng']['scratch_dir']}/nat")
+    expect(chef_run).to create_directory("#{node['iptables-ng']['scratch_dir']}/mangle")
+    expect(chef_run).to create_directory("#{node['iptables-ng']['scratch_dir']}/raw")
   end
 
   it 'should apply default policies' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/attribute_enabled_tables_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/attribute_enabled_tables_test.rb
@@ -4,31 +4,31 @@ describe 'iptables-ng::default' do
   include Helpers::TestHelpers
 
   it 'should not create default mangle FORARD policy' do
-    file('/etc/iptables.d/mangle/FORWARD/default').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/mangle/FORWARD/default").wont_exist
   end
 
   it 'should not create default nat FORARD policy' do
-    file('/etc/iptables.d/nat/FORWARD/default').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/nat/FORWARD/default").wont_exist
   end
 
   it 'should not create default raw FORARD policy' do
-    file('/etc/iptables.d/raw/default').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/raw/default").wont_exist
   end
 
   it 'should not create iptables OUTPUT test_rule' do
-    file('/etc/iptables.d/filter/OUTPUT/testrule-filter-OUTPUT-attribute-rule.rule_v4').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/filter/OUTPUT/testrule-filter-OUTPUT-attribute-rule.rule_v4").wont_exist
   end
 
   it 'should not create ip6tables OUTPUT test_rule' do
-    file('/etc/iptables.d/filter/OUTPUT/testrule-filter-OUTPUT-attribute-rule.rule_v6').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/filter/OUTPUT/testrule-filter-OUTPUT-attribute-rule.rule_v6").wont_exist
   end
 
   it 'should create SSH iptables rule' do
-    file('/etc/iptables.d/filter/INPUT/ssh-filter-INPUT-attribute-rule.rule_v4').must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ssh-filter-INPUT-attribute-rule.rule_v4").must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
   end
 
   it 'should create SSH ip6tables rule' do
-    file('/etc/iptables.d/filter/INPUT/ssh-filter-INPUT-attribute-rule.rule_v6').must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ssh-filter-INPUT-attribute-rule.rule_v6").must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
   end
 
   it 'should apply SSH iptables rule' do
@@ -40,11 +40,11 @@ describe 'iptables-ng::default' do
   end
 
   it 'should create ipv4_only iptables rule' do
-    file('/etc/iptables.d/filter/INPUT/ipv4_only-filter-INPUT-attribute-rule.rule_v4').must_include('--protocol tcp --source 1.2.3.4 --dport 123 --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ipv4_only-filter-INPUT-attribute-rule.rule_v4").must_include('--protocol tcp --source 1.2.3.4 --dport 123 --jump ACCEPT')
   end
 
   it 'should not create ipv4_only ip6tables rule' do
-    file('/etc/iptables.d/filter/INPUT/ipv4_only-filter-INPUT-attribute-rule.rule_v6').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ipv4_only-filter-INPUT-attribute-rule.rule_v6").wont_exist
   end
 
   it 'should apply ipv4_only iptables rule' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_chain_create_custom_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_chain_create_custom_test.rb
@@ -4,7 +4,7 @@ describe 'iptables-ng::lwrp_chaincreate_custom' do
   include Helpers::TestHelpers
 
   it 'should set default mangle FORARD policy to DROP' do
-    file('/etc/iptables.d/mangle/FORWARD/default').must_include('DROP [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/mangle/FORWARD/default").must_include('DROP [0:0]')
   end
 
   it 'should enable iptables serices' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_chain_create_default_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_chain_create_default_test.rb
@@ -4,7 +4,7 @@ describe 'iptables-ng::lwrp_chain_create_default' do
   include Helpers::TestHelpers
 
   it 'should set default FORWARD policy to DROP' do
-    file('/etc/iptables.d/filter/FORWARD/default').must_include('DROP [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/FORWARD/default").must_include('DROP [0:0]')
   end
 
   it 'should enable iptables serices' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_chain_create_empty_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_chain_create_empty_test.rb
@@ -4,7 +4,7 @@ describe 'iptables-ng::lwrp_chain_create_empty' do
   include Helpers::TestHelpers
 
   it 'should create empty custom chain' do
-    file('/etc/iptables.d/filter/EMPTY/default').must_include('- [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/EMPTY/default").must_include('- [0:0]')
   end
 
   it 'should enable iptables serices' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_chain_create_if_missing_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_chain_create_if_missing_test.rb
@@ -4,7 +4,7 @@ describe 'iptables-ng::lwrp_chain_create_if_missing' do
   include Helpers::TestHelpers
 
   it 'should not default FORWARD policy to DROP' do
-    file('/etc/iptables.d/filter/FORWARD/default').wont_include('DROP [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/FORWARD/default").wont_include('DROP [0:0]')
   end
 
   it 'should enable iptables serices' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_chain_delete_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_chain_delete_test.rb
@@ -4,6 +4,6 @@ describe 'iptables-ng::lwrp_chain_create' do
   include Helpers::TestHelpers
 
   it 'should delete default FORWARD policy' do
-    file('/etc/iptables.d/filter/FORWARD/default').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/filter/FORWARD/default").wont_exist
   end
 end

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_custom_chain_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_custom_chain_test.rb
@@ -4,15 +4,15 @@ describe 'iptables-ng::lwrp_create_custom_chain' do
   include Helpers::TestHelpers
 
   it 'should create the custom chain directory' do
-    directory('/etc/iptables.d/nat/FOO').must_exist
+    directory("#{node['iptables-ng']['scratch_dir']}/nat/FOO").must_exist
   end
 
   it 'should set custom iptables rule' do
-    file('/etc/iptables.d/nat/FOO/custom-chain-output.rule_v4').must_include('--protocol icmp --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/nat/FOO/custom-chain-output.rule_v4").must_include('--protocol icmp --jump ACCEPT')
   end
 
   it 'should not set custom ip6tables rule for nat chain' do
-    file('/etc/iptables.d/nat/FOO/custom-chain-output.rule_v6').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/nat/FOO/custom-chain-output.rule_v6").wont_exist
   end
 
   it 'should enable iptables serices' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_custom_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_custom_test.rb
@@ -4,11 +4,11 @@ describe 'iptables-ng::lwrp_create_custom' do
   include Helpers::TestHelpers
 
   it 'should set custom iptables rule' do
-    file('/etc/iptables.d/nat/OUTPUT/custom-output.rule_v4').must_include('--protocol icmp --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/nat/OUTPUT/custom-output.rule_v4").must_include('--protocol icmp --jump ACCEPT')
   end
 
   it 'should not set custom ip6tables rule for nat chain' do
-    file('/etc/iptables.d/nat/OUTPUT/custom-output.rule_v6').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/nat/OUTPUT/custom-output.rule_v6").wont_exist
   end
 
   it 'should enable iptables serices' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_default_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_default_test.rb
@@ -4,11 +4,11 @@ describe 'iptables-ng::lwrp_rule_create_default' do
   include Helpers::TestHelpers
 
   it 'should set SSH iptables rule' do
-    file('/etc/iptables.d/filter/INPUT/ssh.rule_v4').must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ssh.rule_v4").must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
   end
 
   it 'should set SSH ip6tables rule' do
-    file('/etc/iptables.d/filter/INPUT/ssh.rule_v6').must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ssh.rule_v6").must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
   end
 
   it 'should enable iptables serices' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_if_missing_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_if_missing_test.rb
@@ -4,13 +4,13 @@ describe 'iptables-ng::lwrp_rule_create_if_missing' do
   include Helpers::TestHelpers
 
   it 'should set SSH iptables rule' do
-    file('/etc/iptables.d/filter/INPUT/ssh.rule_v4').must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
-    file('/etc/iptables.d/filter/INPUT/ssh.rule_v4').wont_include('--protocol tcp --dport 80 --match state --state NEW --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ssh.rule_v4").must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ssh.rule_v4").wont_include('--protocol tcp --dport 80 --match state --state NEW --jump ACCEPT')
   end
 
   it 'should set SSH ip6tables rule' do
-    file('/etc/iptables.d/filter/INPUT/ssh.rule_v6').must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
-    file('/etc/iptables.d/filter/INPUT/ssh.rule_v6').wont_include('--protocol tcp --dport 80 --match state --state NEW --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ssh.rule_v6").must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ssh.rule_v6").wont_include('--protocol tcp --dport 80 --match state --state NEW --jump ACCEPT')
   end
 
   it 'should enable iptables serices' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_invalid_custom_chain_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_invalid_custom_chain_test.rb
@@ -4,7 +4,7 @@ describe 'iptables-ng::lwrp_create_invalid_custom_chain' do
   include Helpers::TestHelpers
 
   it 'should not create a rule when the chain name is invalid' do
-    file('/etc/iptables.d/nat/FOO/custom-chain-invalid-output.rule_v4').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/nat/FOO/custom-chain-invalid-output.rule_v4").wont_exist
   end
 
   it 'should enable iptables serices' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_toolong_custom_chain_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_create_toolong_custom_chain_test.rb
@@ -4,7 +4,7 @@ describe 'iptables-ng::lwrp_create_toolong_custom_chain' do
   include Helpers::TestHelpers
 
   it 'should not create a rule when the chain name is too long' do
-    file('/etc/iptables.d/nat/FOO/custom-chain-toolong-output.rule_v4').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/nat/FOO/custom-chain-toolong-output.rule_v4").wont_exist
   end
 
   it 'should enable iptables serices' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_delete_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/lwrp_rule_delete_test.rb
@@ -4,11 +4,11 @@ describe 'iptables-ng::lwrp_rule_delete' do
   include Helpers::TestHelpers
 
   it 'should not set HTTP rule' do
-    file('/etc/iptables.d/filter/INPUT/http.rule_v4').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/http.rule_v4").wont_exist
   end
 
   it 'should not set HTTP ip6tables rule' do
-    file('/etc/iptables.d/filter/INPUT/http.rule_v6').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/http.rule_v6").wont_exist
   end
 
   it 'should enable iptables serices' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/recipe_default_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/recipe_default_test.rb
@@ -4,7 +4,7 @@ describe 'iptables-ng::default' do
   include Helpers::TestHelpers
 
   it 'should set default filter FORWARD policy to DROP' do
-    file('/etc/iptables.d/filter/FORWARD/default').must_include('DROP [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/FORWARD/default").must_include('DROP [0:0]')
   end
 
   it 'should apply default filter FORWARD policy' do
@@ -16,11 +16,11 @@ describe 'iptables-ng::default' do
   end
 
   it 'should create iptables OUTPUT test_rule' do
-    file('/etc/iptables.d/filter/OUTPUT/testrule-filter-OUTPUT-attribute-rule.rule_v4').must_include('--protocol icmp --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/OUTPUT/testrule-filter-OUTPUT-attribute-rule.rule_v4").must_include('--protocol icmp --jump ACCEPT')
   end
 
   it 'should create ip6tables OUTPUT test_rule' do
-    file('/etc/iptables.d/filter/OUTPUT/testrule-filter-OUTPUT-attribute-rule.rule_v6').must_include('--protocol icmp --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/OUTPUT/testrule-filter-OUTPUT-attribute-rule.rule_v6").must_include('--protocol icmp --jump ACCEPT')
   end
 
   it 'should apply iptables OUTPUT test_rule' do
@@ -33,7 +33,7 @@ describe 'iptables-ng::default' do
   end
 
   it 'should set default mangle FORARD policy to DROP' do
-    file('/etc/iptables.d/mangle/FORWARD/default').must_include('DROP [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/mangle/FORWARD/default").must_include('DROP [0:0]')
   end
 
   it 'should apply default mangle FORARD policy' do
@@ -45,11 +45,11 @@ describe 'iptables-ng::default' do
   end
 
   it 'should create nat POSTROUTING iptables rule' do
-    file('/etc/iptables.d/nat/POSTROUTING/nat_test-nat-POSTROUTING-attribute-rule.rule_v4').must_include('--protocol tcp -j ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/nat/POSTROUTING/nat_test-nat-POSTROUTING-attribute-rule.rule_v4").must_include('--protocol tcp -j ACCEPT')
   end
 
   it 'should not create custom ip6tables rule for nat chain' do
-    file('/etc/iptables.d/nat/POSTROUTING/nat_test-nat-POSTROUTING-attribute-rule.rule_v6').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/nat/POSTROUTING/nat_test-nat-POSTROUTING-attribute-rule.rule_v6").wont_exist
   end
 
   it 'should apply nat POSTROUTING iptables rule' do
@@ -58,11 +58,11 @@ describe 'iptables-ng::default' do
   end
 
   it 'should create SSH iptables rule' do
-    file('/etc/iptables.d/filter/INPUT/ssh-filter-INPUT-attribute-rule.rule_v4').must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ssh-filter-INPUT-attribute-rule.rule_v4").must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
   end
 
   it 'should create SSH ip6tables rule' do
-    file('/etc/iptables.d/filter/INPUT/ssh-filter-INPUT-attribute-rule.rule_v6').must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ssh-filter-INPUT-attribute-rule.rule_v6").must_include('--protocol tcp --dport 22 --match state --state NEW --jump ACCEPT')
   end
 
   it 'should apply SSH iptables rule' do
@@ -74,11 +74,11 @@ describe 'iptables-ng::default' do
   end
 
   it 'should create ipv4_only iptables rule' do
-    file('/etc/iptables.d/filter/INPUT/ipv4_only-filter-INPUT-attribute-rule.rule_v4').must_include('--protocol tcp --source 1.2.3.4 --dport 123 --jump ACCEPT')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ipv4_only-filter-INPUT-attribute-rule.rule_v4").must_include('--protocol tcp --source 1.2.3.4 --dport 123 --jump ACCEPT')
   end
 
   it 'should not create ipv4_only ip6tables rule' do
-    file('/etc/iptables.d/filter/INPUT/ipv4_only-filter-INPUT-attribute-rule.rule_v6').wont_exist
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/ipv4_only-filter-INPUT-attribute-rule.rule_v6").wont_exist
   end
 
   it 'should apply ipv4_only iptables rule' do

--- a/test/cookbooks/iptables_ng_test/files/default/tests/minitest/recipe_install_test.rb
+++ b/test/cookbooks/iptables_ng_test/files/default/tests/minitest/recipe_install_test.rb
@@ -4,22 +4,22 @@ describe 'iptables-ng::install' do
   include Helpers::TestHelpers
 
   it 'should set all default policies to ACCEPT' do
-    file('/etc/iptables.d/filter/INPUT/default').must_include('ACCEPT [0:0]')
-    file('/etc/iptables.d/filter/OUTPUT/default').must_include('ACCEPT [0:0]')
-    file('/etc/iptables.d/filter/FORWARD/default').must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/INPUT/default").must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/OUTPUT/default").must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/filter/FORWARD/default").must_include('ACCEPT [0:0]')
 
-    file('/etc/iptables.d/nat/OUTPUT/default').must_include('ACCEPT [0:0]')
-    file('/etc/iptables.d/nat/PREROUTING/default').must_include('ACCEPT [0:0]')
-    file('/etc/iptables.d/nat/POSTROUTING/default').must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/nat/OUTPUT/default").must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/nat/PREROUTING/default").must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/nat/POSTROUTING/default").must_include('ACCEPT [0:0]')
 
-    file('/etc/iptables.d/mangle/INPUT/default').must_include('ACCEPT [0:0]')
-    file('/etc/iptables.d/mangle/OUTPUT/default').must_include('ACCEPT [0:0]')
-    file('/etc/iptables.d/mangle/FORWARD/default').must_include('ACCEPT [0:0]')
-    file('/etc/iptables.d/mangle/PREROUTING/default').must_include('ACCEPT [0:0]')
-    file('/etc/iptables.d/mangle/POSTROUTING/default').must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/mangle/INPUT/default").must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/mangle/OUTPUT/default").must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/mangle/FORWARD/default").must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/mangle/PREROUTING/default").must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/mangle/POSTROUTING/default").must_include('ACCEPT [0:0]')
 
-    file('/etc/iptables.d/raw/OUTPUT/default').must_include('ACCEPT [0:0]')
-    file('/etc/iptables.d/raw/PREROUTING/default').must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/raw/OUTPUT/default").must_include('ACCEPT [0:0]')
+    file("#{node['iptables-ng']['scratch_dir']}/raw/PREROUTING/default").must_include('ACCEPT [0:0]')
   end
 
   it 'should not apply other iptables rules' do


### PR DESCRIPTION
this will be handy for handling multiple rule sets
