### PR TITLE
Add possibility to disable the reload or restore of iptables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ iptables-ng CHANGELOG
 
 This file is used to list changes made in each version of the iptables-ng cookbook.
 
+2.2.6
+-----
+
+- Add possibility to disable the reload or restore of iptables at the end of a chef run
+
 2.2.5
 -----
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,11 @@ default['iptables-ng']['enabled_ip_versions'] = [4, 6]
 # necessary to remove the "nat" and "raw" tables.
 default['iptables-ng']['enabled_tables'] = %w(nat filter mangle raw)
 
+# Configure whether the service should be managed by Chef
+# /!\ Be careful when using this feature as it might leave your server in an inconsistent state.
+# See https://github.com/chr4-cookbooks/iptables-ng/pull/42 for more details.
+default['iptables-ng']['managed_service'] = true
+
 # Enable nat support for ipv6
 # Older distributions do not support ipv6 nat, but recent Ubuntu does
 default['iptables-ng']['ip6tables_nat_support'] = value_for_platform(

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'me@chr4.org'
 license          'GNU Public License 3.0'
 description      'Installs/Configures iptables-ng'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.2.5'
+version          '2.2.6'
 
 %w(ubuntu debian
    redhat centos amazon suse scientific

--- a/recipes/manage.rb
+++ b/recipes/manage.rb
@@ -41,8 +41,10 @@ ruby_block 'restart_iptables' do
       include Iptables::Manage
     end
 
-    Array(node['iptables-ng']['enabled_ip_versions']).each do |ip_version|
-      restart_service(ip_version)
+    if node['iptables-ng']['managed_service']
+      Array(node['iptables-ng']['enabled_ip_versions']).each do |ip_version|
+        restart_service(ip_version)
+      end
     end
   end
 


### PR DESCRIPTION
At the end of a chef run.

This is useful in some situations where another service is adding rules to iptables and you actually want to control when the rules added by Chef are actually applied on the server (if you are using Docker for instance).