### PR TITLE
Add support for Debian 8 (Jessie)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,8 +66,14 @@ when 'debian'
     default['iptables-ng']['script_ipv4'] = '/etc/iptables/rules'
     default['iptables-ng']['script_ipv6'] = '/etc/iptables/rules.v6'
   else
-    default['iptables-ng']['service_ipv4'] = 'iptables-persistent'
-    default['iptables-ng']['service_ipv6'] = 'iptables-persistent'
+    if node['platform_version'].to_f >= 8.0
+      default['iptables-ng']['service_ipv4'] = 'netfilter-persistent'
+      default['iptables-ng']['service_ipv6'] = 'netfilter-persistent'
+    else
+      default['iptables-ng']['service_ipv4'] = 'iptables-persistent'
+      default['iptables-ng']['service_ipv6'] = 'iptables-persistent'
+    end
+
     default['iptables-ng']['script_ipv4'] = '/etc/iptables/rules.v4'
     default['iptables-ng']['script_ipv6'] = '/etc/iptables/rules.v6'
   end


### PR DESCRIPTION
The cookbook currently doesn't work on Debian 8 (Jessie), because they've renamed the service from iptables-persistant to netfilter-persistant.
