### PR TITLE
Remove unnecessary directory resource

### DIFF
--- a/providers/rule.rb
+++ b/providers/rule.rb
@@ -49,13 +49,6 @@ def edit_rule(exec_action)
     rule_file = ''
     Array(new_resource.rule).each { |r| rule_file << "--append #{new_resource.chain} #{r.chomp}\n" }
 
-    directory "/etc/iptables.d/#{new_resource.table}/#{new_resource.chain}" do
-      owner  'root'
-      group  node['root_group']
-      mode   00700
-      not_if { exec_action == :delete }
-    end
-
     rule_path = "/etc/iptables.d/#{new_resource.table}/#{new_resource.chain}/#{new_resource.name}.rule_v#{ip_version}"
 
     r = file rule_path do


### PR DESCRIPTION
It's already covered by the preceding iptables_ng_chain resource. This will cut down some of the CHEF-3694 noise. The rest is harder to deal with in this cookbook but should be resolved anyway by chef/chef#2624.