### PR TITLE
Run systemctl daemon-reload on RHEL 7+

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -22,8 +22,8 @@ include_recipe 'iptables-ng::manage'
 
 # Make sure iptables is installed
 Array(node['iptables-ng']['packages']).each do |pkg|
-  # If RHEL 7+ run systemctl daemon-reload to ensure the new services are picked up
-  if node['platform_family'] == 'rhel' && node['platform_version'].to_f >= 7.0
+  # Check to see if we're using systemd so we run systemctl daemon-reload to pick up new services
+  if IO.read('/proc/1/comm').chomp == 'systemd'
     package pkg do
       notifies :run, 'execute[systemctl daemon-reload]', :immediately
     end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -22,18 +22,15 @@ include_recipe 'iptables-ng::manage'
 
 # Make sure iptables is installed
 Array(node['iptables-ng']['packages']).each do |pkg|
-  # Check to see if we're using systemd so we run systemctl daemon-reload to pick up new services
-  if IO.read('/proc/1/comm').chomp == 'systemd'
-    package pkg do
-      notifies :run, 'execute[systemctl daemon-reload]', :immediately
-    end
-  else
-    package pkg
+  package pkg do
+    notifies :run, 'execute[systemctl daemon-reload]', :immediately
   end
 end
 
+# Check to see if we're using systemd so we run systemctl daemon-reload to pick up new services
 execute 'systemctl daemon-reload' do
   action :nothing
+  only_if { IO.read('/proc/1/comm').chomp == 'systemd' }
 end
 
 # Make sure ufw is not installed on Ubuntu/Debian, as it might interfere


### PR DESCRIPTION
On some images (specifically saw it on the Centos7 AMI) I've seen a failure to start up iptables when systemd is in use. The packages get installed but systemd needs to pick up the changes, which a `systemctl daemon-reload` will take care of. Added in a check for the platform family and version to run `systemctl daemon-reload` if we're running RHEL 7+.

I'm not entirely sure what all might be needed from a testing standpoint (I'm somewhat new to cooking with Chef) so please let me know if you need specifics around test scenarios.