### PR TITLE
Fix for Opsworks undefined method `source_url' error

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email 'me@chr4.org'
 license          'GNU Public License 3.0'
 description      'Installs/Configures iptables-ng'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-source_url       'https://github.com/chr4-cookbooks/iptables-ng'
-issues_url       'https://github.com/chr4-cookbooks/iptables-ng/issues'
+source_url       'https://github.com/chr4-cookbooks/iptables-ng' if respond_to?(:source_url)
+issues_url       'https://github.com/chr4-cookbooks/iptables-ng/issues' if respond_to?(:issues_url)
 version          '2.2.10'
 
 %w(ubuntu debian


### PR DESCRIPTION
This resolves these errors on AWS Opsworks:

[2016-04-11T22:49:58+00:00] ERROR: Could not read /opt/aws/opsworks/current/merged-cookbooks/iptables-ng into a Chef object: undefined method `source_url' for #<Chef::Cookbook::Metadata:0x007f11a5836860>
[2016-04-11T22:49:58+00:00] ERROR: #<NoMethodError: undefined method `to_hash' for nil:NilClass>