### PR TITLE
Fix issue with fatal error updating the chain file content

### DIFF
--- a/providers/chain.rb
+++ b/providers/chain.rb
@@ -54,7 +54,7 @@ def edit_chain(exec_action)
 
   begin
     r = run_context.resource_collection.find(file: rule_path)
-    r.content = "#{policy}\n"
+    r.content "#{policy}\n"
     r.updated_by_last_action?
   rescue Chef::Exceptions::ResourceNotFound
     r = file rule_path do


### PR DESCRIPTION
Resources don't have property methods, but have single methods that set/get the value